### PR TITLE
updated travis xcode_sdk version to iphonesimulator9.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,5 @@ sudo: false
 language: objective-c
 xcode_project: ota-app/platforms/ios/OTAApplication.xcodeproj
 xcode_scheme: OTAApplication
-xcode_sdk: iphonesimulator8.1
+xcode_sdk: iphonesimulator9.3
 


### PR DESCRIPTION
travis currently complains while building pull requests:
```
0.87s$ xctool -project ota-app/platforms/ios/OTAApplication.xcodeproj -scheme OTAApplication -sdk iphonesimulator8.1 build test
ERROR: SDK 'iphonesimulator8.1' doesn't exist.  Possible SDKs include: appletvos9.2, iphonesimulator9.3, macosx, watchos, appletvos, appletvsimulator, iphoneos, 
```
so here I'm simply updating travis.yml to specify a new minimum iphonesimulator version for validation.  